### PR TITLE
chore: Simplify install requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,15 +26,9 @@ package_dir =
     = src
 python_requires = >=3.6
 install_requires =
-    numpy
-    pyyaml
-    pyhf>=0.5.3  # paramset.suggested_fixed
-    iminuit>1.5.1 # np_merrors(), parameter limit warning
+    pyhf[minuit]>=0.5.3  # paramset.suggested_fixed
     boost_histogram
-    jsonschema
-    click
     awkward1
-    scipy
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Hi @eschanet. Just thought I'd drop this in to help keep the `install_requires` as clear as possible. This just let's `pyhf` keep track of everything rather than trying to have `simplify` also specify it.