### PR TITLE
Feat/bkg plus signal workspaces

### DIFF
--- a/src/simplify/cli/__init__.py
+++ b/src/simplify/cli/__init__.py
@@ -56,11 +56,17 @@ def simplify() -> None:
     multiple=True,
     help="Process to be excluded in computation of fitted yields",
 )
+@click.option(
+    '--dummy-signal/--no-dummy-signal',
+    default=False,
+    help="Output simplified likelihood with or without dummy signal",
+)
 def convert(
     workspace: str,
+    dummy_signal: bool = False,
+    output_file: Optional[str] = None,
     fixed_pars: Optional[List[str]] = None,
     exclude_process: Optional[List[str]] = None,
-    output_file: Optional[str] = None,
 ) -> None:
 
     fixed_pars = fixed_pars or []
@@ -93,7 +99,7 @@ def convert(
 
     # Hand yields to simplified LH builder and get simplified LH
     newspec = simplified.get_simplified_spec(
-        spec, ylds, allowed_modifiers=["lumi"], prune_channels=[]
+        spec, ylds, allowed_modifiers=[], prune_channels=[], include_signal=dummy_signal
     )
 
     if output_file is None:

--- a/src/simplify/simplified.py
+++ b/src/simplify/simplified.py
@@ -16,6 +16,7 @@ def get_simplified_spec(
     ylds: yields.Yields,
     allowed_modifiers: List[str],
     prune_channels: List[str],
+    include_signal: bool = False,
 ) -> pyhf.workspace:
 
     newspec = {
@@ -25,7 +26,6 @@ def get_simplified_spec(
                 'samples': [
                     {
                         'name': 'Bkg',
-                        # 'data': yields.yields[channel['name']],
                         'data': ylds.yields[channel['name']]
                         .sum(axis=0)
                         .flatten()
@@ -86,5 +86,25 @@ def get_simplified_spec(
         ],
         'version': spec['version'],
     }
+
+    if include_signal:
+        channels_with_signal = [
+            {
+                'name': c['name'],
+                'samples': c['samples']
+                + [
+                    {
+                        "name": "Signal",
+                        "data": [0]
+                        * len(ylds.yields[c['name']].sum(axis=0).flatten().tolist()),
+                        "modifiers": [
+                            {"data": None, "name": "mu_Sig", "type": "normfactor"}
+                        ],
+                    }
+                ],
+            }
+            for c in newspec['channels']
+        ]
+        newspec['channels'] = channels_with_signal
 
     return newspec

--- a/src/simplify/simplified.py
+++ b/src/simplify/simplified.py
@@ -95,7 +95,7 @@ def get_simplified_spec(
                 + [
                     {
                         "name": "Signal",
-                        "data": [0]
+                        "data": [0.0]
                         * len(ylds.yields[c['name']].sum(axis=0).flatten().tolist()),
                         "modifiers": [
                             {"data": None, "name": "mu_Sig", "type": "normfactor"}


### PR DESCRIPTION
Create simplified likelihoods that include a dummy signal sample using
`simplify convert --dummy-signal < BkgOnly.json > simplified_likelihood.json`

This simplifies JSON patching in scenarios where yields are given as list of bins, allowing to do a simple `replace` instead of an `add` (which can be tricky to figure out if multiple bins per channel need to be patched in one after the other).