### PR TITLE
ci: Migrate linting to separate GitHub Actions workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,17 +27,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .[test]
-    - name: Static code analysis with flake8 and mypy
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 src/simplify --select=E9,F63,F7,F82 --show-source
-        # check for additional issues flagged by flake8
-        flake8
-        # run mypy for type checking
-        mypy
-    - name: Format with Black
-      run: |
-        black --check --diff --verbose .
     - name: Test with pytest and generate coverage report
       run: |
         pytest --cov-report=xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+
+    name: Lint Codebase
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install .[test]
+        python -m pip list
+
+    - name: Lint Python source with flake8
+      run: flake8 src/simplify --select=E9,F63,F7,F82 --show-source
+
+    - name: Lint codebase with flake8
+      run: flake8 .
+
+    - name: Lint with mypy
+      run: mypy
+
+    - name: Lint with Black
+      run: black --check --diff --verbose .


### PR DESCRIPTION
At the moment the linting of the code base runs in the same GitHub Actions workflow as the tests _before_ the tests, which means that if the linting fails for any reason then the tests never run, making it harder to know if a PR should be merged or not. This PR migrates the linting out to a separate workflow that runs on PRs and on workflow dispatch through manual triggers.

As a good example of why this is useful, this PR will fail the linting workflow given that there are current `mypy` errors, but the tests ~~will~~ could pass. :+1: 

**Suggested squash and merge commit message**:
```
* Migrate linting out of CI workflow and into a separate GitHub Actions workflow
* Split flake8 checks out between simplify src and the entire codebase
```