### PR TITLE
fix: Update with_aux to include_auxdata in pyhf v0.6.3+ API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir =
     = src
 python_requires = >=3.7
 install_requires =
-    pyhf[minuit]~=0.6
+    pyhf[minuit]>=0.6.3
     boost_histogram
     awkward1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir =
     = src
 python_requires = >=3.7
 install_requires =
-    pyhf[minuit]==0.5.4  # paramset.suggested_fixed
+    pyhf[minuit]~=0.6
     boost_histogram
     awkward1
 

--- a/src/simplify/fitter.py
+++ b/src/simplify/fitter.py
@@ -83,7 +83,7 @@ def fit(
     uncertainty = result[:, 1]
     labels = model_tools.get_parameter_names(model)
     types = model_tools.get_parameter_types(model)
-    corr_mat = result_obj.minuit.np_matrix(correlation=True, skip_fixed=False)
+    corr_mat = result_obj.corr
     cov_mat = result_obj.hess_inv
     best_twice_nll = float(result_obj.fun)
 

--- a/src/simplify/model_tools.py
+++ b/src/simplify/model_tools.py
@@ -13,7 +13,7 @@ def model_and_data(
     spec: Union[Dict[str, Any], pyhf.Workspace],
     poi_name: Optional[str] = None,
     asimov: bool = False,
-    with_aux: bool = True,
+    include_auxdata: bool = True,
 ) -> Tuple[pyhf.pdf.Model, List[float]]:
     """Returns model and data for a pyhf workspace spec in str or workspace format.
 
@@ -21,7 +21,7 @@ def model_and_data(
         spec (Union[Dict[str, Any], pyhf.Workspace]): a pyhf workspace specification
         poi_name (Optional[str], optional): name of the POI. Defaults to None.
         asimov (bool, optional): whether to return Asimov data instead. Defaults to False.
-        with_aux (bool, optional): whether auxiliary data should be returned. Defaults to True.
+        include_auxdata (bool, optional): whether auxiliary data should be returned. Defaults to True.
 
     Returns:
         Tuple[pyhf.pdf.Model, List[float]]:
@@ -38,9 +38,9 @@ def model_and_data(
         poi_name=poi_name,
     )
     if not asimov:
-        data = workspace.data(model, with_aux=with_aux)
+        data = workspace.data(model, include_auxdata=include_auxdata)
     else:
-        data = get_asimov_data(model, with_aux=with_aux)
+        data = get_asimov_data(model, include_auxdata=include_auxdata)
     return model, data
 
 
@@ -117,19 +117,19 @@ def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     return np.asarray(prefit_unc)
 
 
-def get_asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
+def get_asimov_data(model: pyhf.Model, include_auxdata: bool = True) -> List[float]:
     """Gets the asimov dataset for a model
 
     Args:
         model (pyhf.Model): the model for which to construct the asimov data
-        with_aux (bool, optional): with or without auxdata. Defaults to True.
+        include_auxdata (bool, optional): with or without auxdata. Defaults to True.
 
     Returns:
         List[float]: asimov dataset
     """
 
     asimov_data = model.expected_data(
-        get_asimov_parameters(model), include_auxdata=with_aux
+        get_asimov_parameters(model), include_auxdata=include_auxdata
     ).tolist()
     return asimov_data
 

--- a/src/simplify/plot.py
+++ b/src/simplify/plot.py
@@ -110,7 +110,7 @@ def data_MC(
         it automatically determines what to use.
     """
 
-    model, _ = model_tools.model_and_data(spec, with_aux=False)
+    model, _ = model_tools.model_and_data(spec, include_auxdata=False)
     ylds = yields._get_data_yield_uncertainties(spec, fit_results)
 
     if fit_results is not None:

--- a/src/simplify/yields.py
+++ b/src/simplify/yields.py
@@ -112,7 +112,7 @@ def _get_data_yield_uncertainties(
 
     """
 
-    model, data_combined = model_tools.model_and_data(spec, with_aux=False)
+    model, data_combined = model_tools.model_and_data(spec, include_auxdata=False)
 
     if fit_results is not None:
         param_values = fit_results.bestfit

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -35,7 +35,7 @@ def test_model_and_data(example_spec):
     assert data == [691, 1.0]
 
     # without auxdata
-    model, data = model_tools.model_and_data(example_spec, with_aux=False)
+    model, data = model_tools.model_and_data(example_spec, include_auxdata=False)
     assert data == [691]
 
 


### PR DESCRIPTION
See scikit-hep/pyhf#1562 . This makes simplify compatible with more recent pyhf versions.

```
* Set minimum required pyhf version to v0.6.3
   - Set lower bound on pyhf instead of pinning
* Update API to be compatible with pyhf v0.6.3
   - Update iminuit API calls
```