### PR TITLE
build: Revise MANIFEST.in strategy to properly use prune

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,20 +18,25 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
+
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.9"
+
       - name: Install python-build, check-manifest, and twine
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install build check-manifest twine
+
       - name: Check MANIFEST
         run: |
           check-manifest
+
       - name: Build a wheel and a sdist
         run: |
           python -m build --sdist --wheel --outdir dist/ .
+
       - name: Verify untagged commits have dev versions
         if: "!startsWith(github.ref, 'refs/tags/')"
         run: |
@@ -50,6 +55,7 @@ jobs:
             echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
           fi
           echo "python-build named built distribution: ${wheel_name}"
+
       - name: Verify tagged commits don't have dev versions
         if: startsWith(github.ref, 'refs/tags')
         run: |
@@ -61,8 +67,10 @@ jobs:
             return 1
           fi
           echo "python-build named built distribution: ${wheel_name}"
+
       - name: Verify the distribution
         run: twine check dist/*
+
       - name: Publish distribution 📦 to Test PyPI
         # every PR will trigger a push event on master, so check the push event is actually coming from master
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'eschanet/simplify'
@@ -71,6 +79,7 @@ jobs:
           user: __token__
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/
+
       - name: Publish distribution 📦 to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'eschanet/simplify'
         uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build a wheel and a sdist
         run: |
-          python -m build --sdist --wheel --outdir dist/ .
+          python -m build --outdir dist/ .
 
       - name: Verify untagged commits have dev versions
         if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Verify the distribution
         run: twine check dist/*
 
+      - name: List contents of sdist
+        run: python -m tarfile --list dist/simplify-*.tar.gz
+
+      - name: List contents of wheel
+        run: python -m zipfile --list dist/simplify-*.whl
+
       - name: Publish distribution 📦 to Test PyPI
         # every PR will trigger a push event on master, so check the push event is actually coming from master
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'eschanet/simplify'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 prune **
 graft src
+graft tests
 
 include setup.py
 include setup.cfg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,11 @@
-prune *
+prune **
 graft src
+
+include setup.py
+include setup.cfg
 include LICENSE
-include CONTRIBUTING.md
+include README.md
+include pyproject.toml
+include MANIFEST.in
 
 global-exclude __pycache__ *.py[cod] .* *.ipynb


### PR DESCRIPTION
c.f. https://github.com/scikit-hep/pyhf/pull/1449 for additional context

As an example of why this is needed, pulling the latest `sdist` from TestPyPI shows that files not in the `MANIFEST.in` are getting added to the `sdist` as `prune *` no longer works how we used to think it did.

```console
$ curl -sLO https://test-files.pythonhosted.org/packages/4a/d3/562acaa4f82b9f8905939e3133582b374bce65641155ff6e3cf1fa195fad/simplify-0.1.10.dev27.tar.gz
$ python -m tarfile --list simplify-0.1.10.dev27.tar.gz 
simplify-0.1.10.dev27/ 
simplify-0.1.10.dev27/CONTRIBUTING.md 
simplify-0.1.10.dev27/LICENSE 
simplify-0.1.10.dev27/MANIFEST.in 
simplify-0.1.10.dev27/PKG-INFO 
simplify-0.1.10.dev27/README.md 
simplify-0.1.10.dev27/codecov.yml 
simplify-0.1.10.dev27/pyproject.toml 
simplify-0.1.10.dev27/setup.cfg 
simplify-0.1.10.dev27/setup.py 
simplify-0.1.10.dev27/src/ 
simplify-0.1.10.dev27/src/simplify/ 
simplify-0.1.10.dev27/src/simplify/__init__.py 
simplify-0.1.10.dev27/src/simplify/_version.py 
simplify-0.1.10.dev27/src/simplify/benchmark.py 
simplify-0.1.10.dev27/src/simplify/cli/ 
simplify-0.1.10.dev27/src/simplify/cli/__init__.py 
simplify-0.1.10.dev27/src/simplify/configuration.py 
simplify-0.1.10.dev27/src/simplify/exceptions.py 
simplify-0.1.10.dev27/src/simplify/fitter.py 
simplify-0.1.10.dev27/src/simplify/helpers/ 
simplify-0.1.10.dev27/src/simplify/helpers/__init__.py 
simplify-0.1.10.dev27/src/simplify/helpers/plotting.py 
simplify-0.1.10.dev27/src/simplify/model_tools.py 
simplify-0.1.10.dev27/src/simplify/plot.py 
simplify-0.1.10.dev27/src/simplify/simplified.py 
simplify-0.1.10.dev27/src/simplify/yields.py 
simplify-0.1.10.dev27/src/simplify.egg-info/ 
simplify-0.1.10.dev27/src/simplify.egg-info/PKG-INFO 
simplify-0.1.10.dev27/src/simplify.egg-info/SOURCES.txt 
simplify-0.1.10.dev27/src/simplify.egg-info/dependency_links.txt 
simplify-0.1.10.dev27/src/simplify.egg-info/entry_points.txt 
simplify-0.1.10.dev27/src/simplify.egg-info/requires.txt 
simplify-0.1.10.dev27/src/simplify.egg-info/top_level.txt 
root@0b62dca977c7:/# 
```

```
* Remove global exclude of dotfiles from MANIFEST.in to avoid potential problems with build systems
   - c.f. https://github.com/scikit-build/scikit-build/issues/537
* Use `prune **` to remove all files from the sdist
   - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
   - "Setuptools also has undocumented support for ** matching zero or more characters including forward slash, backslash, and colon."
* Manually include all "default" files for a sdist in MANIFEST.in
   - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
* Add list of sdist and wheel contents to package publishing CI
   - Allow for easier checking of the sdist and wheel contents in CI logs
```