### PR TITLE
fix: Fix linting to pass pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v2.29.0
     hooks:
     -   id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py37-plus"]
 
 -   repo: https://github.com/psf/black
     rev: 21.10b0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,30 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-    -   id: black
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
-    hooks:
-    -   id: mypy
-        files: src/simplify
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
-    hooks:
-    -   id: flake8
-        additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
--   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
-    hooks:
-    -   id: pyupgrade
-        args: ["--py38-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.0.1
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]
     -   id: trailing-whitespace
+
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+    -   id: pyupgrade
+        args: ["--py38-plus"]
+
+-   repo: https://github.com/psf/black
+    rev: 21.10b0
+    hooks:
+    -   id: black-jupyter
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    -   id: flake8
+        additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910-1
+    hooks:
+    -   id: mypy
+        files: src/simplify

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,4 @@ repos:
     hooks:
     -   id: mypy
         files: src/simplify
+        additional_dependencies: [types-PyYAML==6.0.0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ filterwarnings =
     ignore:no type annotations present:UserWarning:typeguard:
 
 [flake8]
+# E501: line too long
+extend-ignore = E501
 max-complexity = 12
 max-line-length = 88
 count = True

--- a/src/simplify/fitter.py
+++ b/src/simplify/fitter.py
@@ -32,7 +32,7 @@ def print_results(
     fit_result : FitResults
         Results of the fit to be printed.
     """
-    max_label_length = max([len(label) for label in fit_result.labels])
+    max_label_length = max(len(label) for label in fit_result.labels)
     for i, label in enumerate(fit_result.labels):
         log.info(
             f"{label.ljust(max_label_length)}: {fit_result.bestfit[i]: .6f} +/- "

--- a/src/simplify/helpers/plotting.py
+++ b/src/simplify/helpers/plotting.py
@@ -68,7 +68,7 @@ def yieldsTable(
     # FIXME: this still has signal uncertainties
     # in total uncertainty, which is not right!!!!
     # get total region first, then do the bins
-    data_line = "Observed events & ${}$".format(np.sum(data))
+    data_line = f"Observed events & ${np.sum(data)}$"
     total_sm = r'Fitted bkg events & ${:8.3f} \pm {:8.3f}$'.format(
         np.sum(bkgOnly_yields), np.sqrt(np.sum(uncertainties ** 2))
     )
@@ -76,7 +76,7 @@ def yieldsTable(
     # FIXME: same as above, dooh...
     if nbins > 1:
         for i_bin in range(nbins):
-            data_line += " & ${}$".format(data[i_bin])
+            data_line += f" & ${data[i_bin]}$"
             total_sm += r' & ${:8.3f} \pm {:8.3f}$'.format(
                 np.sum(bkgOnly_yields[:, i_bin]), uncertainties[i_bin]
             )
@@ -93,7 +93,7 @@ def yieldsTable(
         )
         if nbins > 1:
             for i_bin in range(nbins):
-                main += " & ${:8.3f}$".format(yields[i_sample, i_bin])
+                main += f" & ${yields[i_sample, i_bin]:8.3f}$"
 
         main += r'''\\
 '''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -55,7 +55,7 @@ def test__get_binning():
     ),
 )
 def test__yieldsTable(mock_unc, mock_draw, example_spec):
-    model_spec = pyhf.Workspace(example_spec).model().spec
+    model_spec = pyhf.Workspace(example_spec).model().spec  # noqa: F841
     table_folder = "tmp"
     fit_results = fitter.FitResults(
         np.asarray([1.1, 5.58731303]),
@@ -73,7 +73,7 @@ def test__yieldsTable(mock_unc, mock_draw, example_spec):
     assert mock_unc.call_count == 1
 
     # create actual yieldstable
-    expected_yieldstable = [
+    expected_yieldstable = [  # noqa: F841
         {
             "label": "signal",
             "isData": False,

--- a/tests/test_simplified.py
+++ b/tests/test_simplified.py
@@ -43,6 +43,5 @@ def test_get_simplified_spec(
     spec = simplified.get_simplified_spec(
         example_full_analysis_likelihood, ylds, allowed_modifiers=[], prune_channels=[]
     )
-    print(spec)
 
     assert spec == example_simplified_analysis_likelihood


### PR DESCRIPTION
Update the pre-commit hooks and get things passing so that `pre-commit run --all-files` passes.

**Suggested squash and merge commit message**:
```
* Update pre-commit hooks
* Reorder pre-commit hooks so hooks that modify code run before checkers
   - Avoids possible failing on secondary runs
* Lower pyupgrade to run with --py37-plus as Python 3.7 is the older Python supported
* Add types-PyYAML as additional dependency to mirrors-mypy pre-commit hook
   - pre-commit runs mypy from an isolated virtualenv so it won't have access to local typing stubs
* Address flake8 errors
   - Ignore E501: line too long
   - Locally ignore F841 local variable is assigned to but never used in tests
   - Remove print in tests for flake8-print
```