### PR TITLE
build: Set lower bounds on all install_requires dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.7
 install_requires =
     pyhf[minuit]>=0.6.3
     boost_histogram
-    awkward1
+    awkward
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.7
 install_requires =
     pyhf[minuit]>=0.6.3
     boost_histogram
-    awkward
+    awkward>=1.0.0
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ package_dir =
 python_requires = >=3.7
 install_requires =
     pyhf[minuit]>=0.6.3
-    boost_histogram
     awkward>=1.0.0
 
 [options.packages.find]

--- a/src/simplify/model_tools.py
+++ b/src/simplify/model_tools.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 import pyhf
 

--- a/src/simplify/simplified.py
+++ b/src/simplify/simplified.py
@@ -2,7 +2,7 @@ import copy
 import logging
 from typing import Any, Dict, List
 
-import awkward1 as ak
+import awkward as ak
 import pyhf
 
 from . import yields

--- a/src/simplify/yields.py
+++ b/src/simplify/yields.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 
 from . import fitter

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,6 +1,6 @@
 import copy
 
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 import pyhf
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,7 +1,7 @@
 import pathlib
 from unittest import mock
 
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 import pyhf
 import pytest

--- a/tests/test_simplified.py
+++ b/tests/test_simplified.py
@@ -1,4 +1,4 @@
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 
 from simplify import simplified, yields

--- a/tests/test_yields.py
+++ b/tests/test_yields.py
@@ -1,4 +1,4 @@
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 import pytest
 


### PR DESCRIPTION
Empirically determine and set minimum required lower bounds on all install dependencies

Adopts modern `awkward` namespace over the old and now deprecated `awkward1` namespace and removes `boost-histogram` as it isn't required to have installed for the tests to pass.


**Suggested squash and merge commit message**:
```
* Set minimum required lower bound of awkward v1.0.0
   - Use awkward namespace over deprecated awkward1
   - Lower bounds empirically determined from tests
* Remove boost-histogram as an installation requirement
```