### PR TITLE
ci: Add CPython 3.9 to testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,24 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install simplify and dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .[test]
+
       - name: Test with pytest and generate coverage report
         run: |
           python -m pytest -r sx
+
       - name: Upload coverage to codecov
-        if: matrix.python-version == 3.7
-        uses: codecov/codecov-action@v1
+        if: matrix.python-version == 3.9
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Development Status :: 3 - Alpha
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     License :: OSI Approved :: BSD License
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,12 @@ project_urls =
     Tracker = https://github.com/eschanet/simplify/issues
 classifiers =
     Development Status :: 3 - Alpha
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: BSD License
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics


### PR DESCRIPTION

```
* Add CPython 3.9 to testing matrix
   - Upload coverage report on Python 3.9
* Update codecov/codecov-action to v2
* Add Python 3.9, Python 3 only, and CPython Implementation PyPI metadata classifiers
```