### PR TITLE
docs: Note that ATLAS PUB Note on simplified likelihoods is public

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For binned data, the [HistFactory](https://cds.cern.ch/record/1456844?ln=de) tem
 
 Although many searches for supersymmetry (SUSY) are sensitive to a variety of beyond the Standard Model (BSM) physics models, for reasons of computational cost and complexity they are often only interpreted in a limited set of *simplified models*. While statistical inference and interpretation of limits on individual SUSY production and decay topologies is straightforward and very convenient, their lack of model complexity leads to poor approximations to the true underlying constraints on the respective model parameters of a more complete SUSY model. In order to investigate realistic SUSY scenarios, large-scale re-interpretation efforts scanning a large number of dimensions is needed, resulting in a significant increase in computational cost for the statistical inference.
 
-The approximation method put forward in [ATLAS PUB Note](https://cds.cern.ch/record/2758958?) and implemented in this repository introduces the notion of *simplified likelihoods* that come with low computational cost but high statistical precision, therefore offering a viable solution for large-scale re-interpretation efforts over large model spaces.
+The approximation method put forward in the ATLAS PUB note [Implementation of simplified likelihoods in HistFactory for searches for supersymmetry](https://cds.cern.ch/record/2782654) and implemented in this repository introduces the notion of *simplified likelihoods* that come with low computational cost but high statistical precision, therefore offering a viable solution for large-scale re-interpretation efforts over large model spaces.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -31,19 +31,20 @@ The approximation method put forward in the ATLAS PUB note [Implementation of si
 ## Installation
 
 Follow good practice and start by creating a virtual environment, e.g. using `venv`
-```sh
+
+```console
 python3 -m venv simplify
 ```
 
 and then activating it
-```sh
+```console
 source simplify/bin/activate
 ```
 
 ### Default installation from pypi
 
 You can install `simplify` directly from pypi with
-```sh
+```console
 python3 -m pip install simplify[contrib]
 ```
 
@@ -52,18 +53,18 @@ Notice that `simplify` is supported and tested for `python 3.7` and `python 3.8`
 ### Development installation
 
 If you want to contribute to `simplify`, install the development version of the package. Fork the repository, clone your fork, and then install from local resources with
-```sh
+```console
 python3 -m pip install --ignore-installed -U -e .[complete]
 ```
 Note that you might have to wrap `.[complete]` into quotes depending on your shell.
 
 Next, setup the git pre-commit hook for Black
-```sh
+```console
 pre-commit install
 ```
 
 Now you should be able to run all the tests with
-```sh
+```console
 python3 -m pytest
 ```
 
@@ -75,13 +76,13 @@ You can use `simplify` either through your command line, or integrate it directl
 
 Run with e.g.
 
-```sh
+```console
 simplify convert < fullLH.json > simplifiedLH.json
 ```
 
 or e.g.
 
-```sh
+```console
 curl http://foo/likelihood.json | simplify convert
 ```
 
@@ -146,24 +147,24 @@ tables = simplify.plot.yieldsTable(
 Let's go through an example likelihood. We'll use the full likelihood of an ATLAS search for direct production of electroweakinos in final states with one lepton and a Higgs boson ([10.1140/epjc/s10052-020-8050-3](https://arxiv.org/abs/1909.09226)). The full likelihood in `JSON` format as specified by [ATL-PHYS-PUB-2019-029](https://cds.cern.ch/record/2684863) is publicly available to download from [doi.org/10.17182](https://www.hepdata.net/record/resource/1408476?view=true). It contains the full statistical model of the original analysis given the full observed dataset from Run-2 of the LHC.
 
 You can either download the likelihood by hand from [HEPData](https://www.hepdata.net/record/resource/1408476?view=true), or just let `pyhf` do the work for you by using
-```sh
+```console
 pyhf contrib download https://doi.org/10.17182/hepdata.90607.v3/r3 1Lbb-likelihoods && cd 1Lbb-likelihoods
 ```
 
 From there, provided you have already setup `simplify` previously (which also sets up `pyhf`), you can produce a simplified likelihood of this analysis with
-```sh
+```console
 simplify convert < BkgOnly.json > simplify_BkgOnly.json
 ```
 
 And you're done. Well, at least you've got yourself a simplified version of that likelihood, which approximates the total background using a single background sample that is set to the post-fit total background determined from the full likelihood. The uncertainties (the expensive part) are approximated using only the final uncertainty on the background estimate in each bin of the analysis.
 
 If you think about it, this gives you quite a simple likelihood function. Let's compare them quickly. For the full likelihood, we can inspect the full likelihood with `pyhf` (and only look at the first 17 lines containing summary of what `pyhf` spits out):
-```sh
+```console
 pyhf inspect BkgOnly.json | head -n 17
 ```
 
 This should give you
-```sh
+```console
        Summary
   ------------------
     channels  8
@@ -186,11 +187,11 @@ This should give you
 Think about this for a second. You've got 8 channels with a total of 14 bins. Each bin contains information about 9 samples, and each event rate for each sample is subject to a total of 115 additional parameters (the uncertainties of the model). This makes for quite a complicated likelihood function.
 
 On to the simplified one then.
-```sh
+```console
 pyhf inspect simplify_BkgOnly.json | head -n 17
 ```
 gives us
-```sh
+```console
        Summary
   ------------------
     channels  8

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ and then activating it
 source simplify/bin/activate
 ```
 
-### Default installation from pypi
+### Default installation from PyPI
 
-You can install `simplify` directly from pypi with
+You can install `simplify` directly from PyPI with
 ```console
 python3 -m pip install simplify[contrib]
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
-A python package that creates simplified likelihoods from full likelihoods. Method documented in [ATLAS PUB Note](https://cds.cern.ch/record/2758958?) (soon to be published, currently only internal access) and in [chapter 10 of my PhD thesis](https://cds.cern.ch/record/2774438/files/CERN-THESIS-2021-077.pdf). Currently, only one format is implemented for simplified likelihoods, but the idea is to support additional forms of (not so) simplified likelihoods.
+A python package that creates simplified likelihoods from full likelihoods. The method is documented in the ATLAS PUB note [Implementation of simplified likelihoods in HistFactory for searches for supersymmetry](https://cds.cern.ch/record/2782654) and in [chapter 10 of Eric Schanet's PhD thesis](https://cds.cern.ch/record/2774438/files/CERN-THESIS-2021-077.pdf). Currently, only one format is implemented for simplified likelihoods, but the idea is to support additional forms of (not so) simplified likelihoods.
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can install `simplify` directly from PyPI with
 python3 -m pip install simplify[contrib]
 ```
 
-Notice that `simplify` is supported and tested for `python 3.7` and `python 3.8`.
+Notice that `simplify` is supported and tested for Python 3.7, Python 3.8, and Python 3.9.
 
 ### Development installation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A python package that creates simplified likelihoods from full likelihoods. The 
 
 ## Introduction
 
-In high energy physics (HEP), searches for new physics are typically interested in making inferences about a probabilistic model given some observed collision data. This approach can be formalised using a *statistical model* <i>f(<b>x</b>&VerticalLine;<b>&phi;</b>)</i>, i.e. a parametric family of probability density functions (PDFs) describing the probability of observing data <i><b>x</b></i> given some model parameters <i><b>&phi;</b></i>. The *likelihood function* <i>L(<b>&phi;</b>)</i> then referrs to the value of *f* as a function of <i><b>&phi;</b></i> given fixed <i><b>x</b></i>.
+In high energy physics (HEP), searches for new physics are typically interested in making inferences about a probabilistic model given some observed collision data. This approach can be formalised using a *statistical model* <i>f(<b>x</b>&VerticalLine;<b>&phi;</b>)</i>, i.e. a parametric family of probability density functions (PDFs) describing the probability of observing data <i><b>x</b></i> given some model parameters <i><b>&phi;</b></i>. The *likelihood function* <i>L(<b>&phi;</b>)</i> then refers to the value of *f* as a function of <i><b>&phi;</b></i> given fixed <i><b>x</b></i>.
 
 For binned data, the [HistFactory](https://cds.cern.ch/record/1456844?ln=de) template for building statistical models and likelihoods finds ample usage in HEP.
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ curl http://foo/likelihood.json | simplify convert
 
 where `fullLH.json` is the full likelihood you want to convert into a simplified likelihood. Simplify is able to read/write from/to stdin/stdout.
 
-Hit `simplify --help` for detailled information on the CLI.
+Hit `simplify --help` for detailed information on the CLI.
 
-### In python script
+### In Python script
 
-You can also use `simplify` in a python script, e.g. to create some validation and cross-check plots and tables.
+You can also use `simplify` in a Python script, e.g. to create some validation and cross-check plots and tables.
 
 ```py
 import pyhf


### PR DESCRIPTION
```
* Update README to include public link to Implementation of simplified likelihoods in HistFactory for searches for supersymmetry (ATL-PHYS-PUB-2021-038)
   - c.f. https://cds.cern.ch/record/2782654
* Change `sh` syntax highlighting to `console` to get better command line agreement
* Fix typos
```