### PR TITLE
build: Remove _version.py from bump2version control

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,5 +4,3 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.cfg]
-
-[bumpversion:file:src/simplify/_version.py]


### PR DESCRIPTION
```
* _version.py is generated from setuptools_scm and so does not need to
be bumped by bump2version
```